### PR TITLE
Add card styling for personal portfolio; hide bottom nav

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,7 @@
+---
+hide:
+  - footer
+---
 # Welcome!
 
 ## `whoami`

--- a/docs/personal.md
+++ b/docs/personal.md
@@ -1,6 +1,34 @@
+---
+hide:
+  - footer
+---
 # Personal work
 
 The following samples are things I just did for fun and because I thought there was a need, or for my own projects.
 
-- [About this site's tech stack: Em Like the Dash](https://github.com/microcosem/emlikethedash?tab=readme-ov-file#-welcome-to-my-digital-corner)
-- [A guide to deploying Caddy as a loadbalancer on GCP](caddy-on-gcp.md)
+<div class="grid cards" markdown>
+
+-   :simple-materialformkdocs: **About This Site: Em Like the Dash**
+
+    ---
+
+    The README documentation for this very site - how it's built, and how to deploy it yourself both locally as well as on Vercel (my chosen hosting platform).
+
+    [:octicons-arrow-right-24: Read](https://github.com/microcosem/emlikethedash?tab=readme-ov-file#-welcome-to-my-digital-corner)
+
+-   :material-google-cloud:{ .lg .middle } **Deploying Caddy for Loadbalancing on GCP**
+
+    ---
+
+    A blog-style post on how to deploy Caddy as a loadbalancer on Google Cloud Platform with Kubernetes.
+
+    [:octicons-arrow-right-24: Read](caddy-on-gcp.md)
+
+-   :material-pencil:{ .lg .middle } **How to Become a Technical Writer (`awesome-technical-writing`)**
+
+    ---
+    A wiki I've started on [my fork](https://github.com/microcosem/awesome-technical-writing) of the awesome-technical-writing [awesome list](https://github.com/topics/awesome-list). Leveraging community contributed resources in the awesome list, I'm writing the wiki to serve as a primer for those looking to get into the career of technical writing for software and digital infrastructure today.
+
+    [:octicons-arrow-right-24: Read](https://github.com/microcosem/awesome-technical-writing/wiki)
+
+</div>

--- a/docs/resume.md
+++ b/docs/resume.md
@@ -1,4 +1,8 @@
-# Resume
+---
+hide:
+  - footer
+---
+# Experience
 [Download PDF :material-tray-arrow-down:](resume2024.pdf){ .md-button }
 [LinkedIn :material-linkedin:](https://www.linkedin.com/in/em-h-2b80992b3){ .md-button }
 [GitHub :material-github:](https://github.com/microcosem){ .md-button }
@@ -11,8 +15,6 @@
 I pursue quality achieved collaboratively. I strive to empower the people I work with to do their best work, to grow, and to feel satisfied in their work. I am a voracious learner, and a big fan of unconventional approaches to problem solving.
 
 ***
-
-## Experience
 
 ### CoreWeave, Inc. – New York (Remote)
 


### PR DESCRIPTION
This PR adds the grid styling (which I'm calling 'cards') from Material for the personal work side of my portfolio. It also hides the automatic bottom-page navigation from some pages.